### PR TITLE
Create dockgen-ubuntu

### DIFF
--- a/bin/dockgen-ubuntu
+++ b/bin/dockgen-ubuntu
@@ -1,0 +1,4 @@
+#!/usr/bin/env nodejs
+var dockgen = require('..');
+
+console.log(dockgen(process.cwd()));


### PR DESCRIPTION
In order to use the gen on Ubuntu, we have to call nodejs instead of node.
